### PR TITLE
Ase atlas tags by index

### DIFF
--- a/flixel/graphics/FlxAsepriteUtil.hx
+++ b/flixel/graphics/FlxAsepriteUtil.hx
@@ -1,6 +1,7 @@
 package flixel.graphics;
 
 import flixel.graphics.frames.FlxAtlasFrames;
+import flixel.math.FlxMath;
 import flixel.system.FlxAssets;
 
 /**
@@ -61,9 +62,18 @@ class FlxAsepriteUtil
 	public static function addAseAtlasTags(sprite:FlxSprite, data:FlxAsepriteJsonAsset, tagSuffix:String = ":")
 	{
 		final aseData = data.getData();
+		var maxFrameIndex = 0;
 		for (frameTag in aseData.meta.frameTags)
-			sprite.animation.addByPrefix(frameTag.name, frameTag.name + tagSuffix);
+		{
+			maxFrameIndex = FlxMath.maxInt(maxFrameIndex, frameTag.to);
+			sprite.animation.add(frameTag.name, [for (i in frameTag.from...frameTag.to + 1) i]);
+		}
 		
+		if (maxFrameIndex >= sprite.frames.numFrames)
+		{
+			FlxG.log.warn('tag frame indices go beyond number of frames. Some animations may not be loaded correctly. Was atlas exported with "Ignore Empty"/--ignore-empty?');
+		}
+
 		return sprite;
 	}
 }

--- a/flixel/graphics/FlxAsepriteUtil.hx
+++ b/flixel/graphics/FlxAsepriteUtil.hx
@@ -40,11 +40,11 @@ class FlxAsepriteUtil
 	 * @see flixel.graphics.FlxAsepriteUtil.AseAtlasMeta
 	 * @since 5.4.0
 	 */
-	public static function loadAseAtlasAndTags(sprite:FlxSprite, graphic, data:FlxAsepriteJsonAsset, tagSuffix:String = ":")
+	public static function loadAseAtlasAndTags(sprite:FlxSprite, graphic, data:FlxAsepriteJsonAsset)
 	{
 		final aseData = data.getData();
 		loadAseAtlas(sprite, graphic, aseData);
-		return addAseAtlasTags(sprite, aseData, tagSuffix);
+		return addAseAtlasTags(sprite, aseData);
 	}
 	
 	/**
@@ -59,7 +59,7 @@ class FlxAsepriteUtil
 	 * @see flixel.graphics.FlxAsepriteUtil.AseAtlasMeta
 	 * @since 5.4.0
 	 */
-	public static function addAseAtlasTags(sprite:FlxSprite, data:FlxAsepriteJsonAsset, tagSuffix:String = ":")
+	public static function addAseAtlasTags(sprite:FlxSprite, data:FlxAsepriteJsonAsset)
 	{
 		final aseData = data.getData();
 		var maxFrameIndex = 0;


### PR DESCRIPTION
Just a POC to save on more rambling (a line of code is worth 1000 words or something like that).

This is just my thoughts on what it would look like if we used the tags `from` and `to`. 

Of course, we talked about the caveat where "Ignore Empty" is used. Not sure about the best practices for logging errors are within flixel. I based this off of [https://github.com/HaxeFlixel/flixel/blob/dev/flixel/animation/FlxAnimationController.hx#L226](FlxAnimationController)