### PR TITLE
Replace `assets` with `collision` in the `FlxG.collision` comment

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -337,7 +337,7 @@ class FlxG
 	public static var assets(default, null):AssetFrontEnd = new AssetFrontEnd();
 
 	/**
-	 * Contains helper functions relating to retrieving assets
+	 * Contains helper functions relating to collision
 	 * @since 6.2.0
 	 */
 	public static var collision(default, null):CollisionFrontEnd = new CollisionFrontEnd();


### PR DESCRIPTION
This PR changes the `FlxG.collision` comment to say `Contains helper functions relating to collision` instead of `Contains helper functions relating to retrieving assets`.


surprised you changed the `@since` but not the actual comment itself lmao